### PR TITLE
Build and install *all* the packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.1
+version = 0.0.2
 
 [nosetests]
 verbosity=1

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="fileflow",
@@ -8,7 +8,7 @@ setup(
     url='https://github.com/industrydive/fileflow',
     license='Apache License 2.0',
     zip_safe=False,
-    packages=['fileflow'],
+    packages=find_packages(exclude=['docs', 'tests*']),
     install_requires=[
         'airflow~=1.7.0',
         'pandas==0.17.0',


### PR DESCRIPTION
closes #3

Uses the [`find_packages`](https://packaging.python.org/distributing/#packages) function from `setuptools` to install all the packages. 

I also bumped the version number, although I'm not 100% sure that's right. I didn't actually change anything, after all. 


### To test
On master, run `python setup.py build` and see what files are created in the `build` folder. Delete said folder, checkout this branch, and run the command again. Everything should be there now.