### PR TITLE
Fix configuration to not require section in airflow.cfg

### DIFF
--- a/fileflow/configuration.py
+++ b/fileflow/configuration.py
@@ -1,11 +1,14 @@
 """
 Extend from the airflow configuration and address any missing fileflow related configuration values.
 """
-from airflow import configuration as airflow_configuration
+from ConfigParser import NoSectionError
+from airflow.configuration import conf as airflow_configuration
 import os
 import boto
 
 # Set some fileflow settings to a default if they do not already exist.
+if not airflow_configuration.has_section('fileflow'):
+    airflow_configuration.add_section('fileflow')
 
 if not airflow_configuration.has_option('fileflow', 'environment'):
     airflow_configuration.set('fileflow', 'environment', 'production')

--- a/fileflow/configuration.py
+++ b/fileflow/configuration.py
@@ -55,10 +55,10 @@ if not airflow_configuration.has_option('fileflow', 'aws_access_key_id'):
 
 if not airflow_configuration.has_option('fileflow', 'aws_secret_access_key'):
     if aws_secret_access_key_env_var:
-        airflow_configuration.set('fileflow', 'aws_secret_acccess_key', aws_secret_access_key_env_var)
+        airflow_configuration.set('fileflow', 'aws_secret_access_key', aws_secret_access_key_env_var)
     else:
         boto_aws_secret_access_key_default = boto_config.get('Credentials', 'aws_secret_access_key')
-        airflow_configuration.set('fileflow', 'aws_secret_acccess_key', boto_aws_secret_access_key_default)
+        airflow_configuration.set('fileflow', 'aws_secret_access_key', boto_aws_secret_access_key_default)
 
 
 def get(section, key, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.0.2
+version = 0.0.3
 
 [nosetests]
 verbosity=1


### PR DESCRIPTION
Closes #5 

This allows a clean build and test from just `setup.py`. Previously, when creating a clean install, airflow freaked out that a `[fileflow]` section of the config file didn't exist. This interfered with testing and building docs, although on a real install it wasn't a problem.

This also fixes a typo in the code that sets the `aws_secret_access_key`.

### To test:
Checkout master in a clean virtualenv (and don't have `AIRFLOW_HOME` set to a custom config file). Run `python setup.py build` and `python setup.py test`. Observe the errors.

Checkout this branch and do the same. Nicer, right?


 