### PR TITLE
(closes #8) Adding full fileflow example to docs.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath('../..'))
 
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -82,7 +81,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -101,31 +99,29 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Fileflowdoc'
 
-
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-     # The paper size ('letterpaper' or 'a4paper').
-     #
-     # 'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
 
-     # The font size ('10pt', '11pt' or '12pt').
-     #
-     # 'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
 
-     # Additional stuff for the LaTeX preamble.
-     #
-     # 'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
 
-     # Latex figure (float) alignment
-     #
-     # 'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
@@ -136,7 +132,6 @@ latex_documents = [
      u'Laura Lorenz, Miriam Sexton, David Barbarisi', 'manual'),
 ]
 
-
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
@@ -145,7 +140,6 @@ man_pages = [
     (master_doc, 'fileflow', u'Fileflow Documentation',
      [author], 1)
 ]
-
 
 # -- Options for Texinfo output -------------------------------------------
 
@@ -157,9 +151,6 @@ texinfo_documents = [
      author, 'Fileflow', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/': None,

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -67,5 +67,36 @@ The two storage drivers shipped in ``fileflow`` deal with the nitty gritty of ac
 
 Since we're working with text I/O obviously this introduces a bunch of decisions the storage drivers have to be making regarding encoding/charsets, file read/write mode, path/key existence, and in the case of putting to S3 over HTTP, content types. All of this is handled by the respective storage driver; the interface for what a storage driver should implement is represented by the base :py:class:`~fileflow.storage_drivers.storage_driver.StorageDriver` class.
 
+A full example
+~~~~~~~~~~~~~~~
 
+.. literalinclude:: ../fileflow/example_dags/fileflow_example.py
+    :language: python
 
+.. code-block:: bash
+
+    (fileflow)fileflow $ airflow run -sd fileflow/example_dags/ fileflow_example write_a_file 2017-01-01
+    [2017-01-18 16:54:55,245] {__init__.py:36} INFO - Using executor SequentialExecutor
+    Sending to executor.
+    [2017-01-18 16:54:56,080] {__init__.py:36} INFO - Using executor SequentialExecutor
+    Logging into: /Users/llorenz/airflow/logs/fileflow_example/write_a_file/2017-01-01T00:00:00
+    [2017-01-18 16:54:56,995] {__init__.py:36} INFO - Using executor SequentialExecutor
+    (fileflow)fileflow $ airflow run -sd fileflow/example_dags/ fileflow_example read_that_file 2017-01-01
+    [2017-01-18 16:55:30,790] {__init__.py:36} INFO - Using executor SequentialExecutor
+    Sending to executor.
+    [2017-01-18 16:55:32,219] {__init__.py:36} INFO - Using executor SequentialExecutor
+    Logging into: /Users/llorenz/airflow/logs/fileflow_example/read_that_file/2017-01-01T00:00:00
+    (fileflow)fileflow $ tree storage/
+    storage/
+    └── fileflow_example
+        ├── read_that_file
+        │   └── 2017-01-01
+        └── write_a_file
+            └── 2017-01-01
+
+    3 directories, 2 files
+    (fileflow)fileflow $ cat storage/fileflow_example/read_that_file/2017-01-01
+    Read 'This task -- called write_a_file -- was run.' from 'storage/fileflow_example/write_a_file/2017-01-01'. Writing output to 'storage/fileflow_example/read_that_file/2017-01-01'.
+    (fileflow)fileflow $ cat storage/fileflow_example/write_a_file/2017-01-01
+    This task -- called write_a_file -- was run.
+    (fileflow)fileflow $

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -70,7 +70,7 @@ Since we're working with text I/O obviously this introduces a bunch of decisions
 A full example
 ~~~~~~~~~~~~~~~
 
-.. literalinclude:: ../fileflow/example_dags/fileflow_example.py
+.. literalinclude:: ../../fileflow/example_dags/fileflow_example.py
     :language: python
 
 .. code-block:: bash

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -68,7 +68,7 @@ The two storage drivers shipped in ``fileflow`` deal with the nitty gritty of ac
 Since we're working with text I/O obviously this introduces a bunch of decisions the storage drivers have to be making regarding encoding/charsets, file read/write mode, path/key existence, and in the case of putting to S3 over HTTP, content types. All of this is handled by the respective storage driver; the interface for what a storage driver should implement is represented by the base :py:class:`~fileflow.storage_drivers.storage_driver.StorageDriver` class.
 
 A full example
-~~~~~~~~~~~~~~~
+--------------
 
 .. literalinclude:: ../../fileflow/example_dags/fileflow_example.py
     :language: python

--- a/fileflow/configuration.py
+++ b/fileflow/configuration.py
@@ -6,6 +6,7 @@ from airflow import configuration as airflow_configuration
 import os
 import boto
 
+
 def _ensure_section_exists(section_name):
     """
     Checks to make sure the config has a section called section_name. If it doesn't, create one.
@@ -24,6 +25,7 @@ def _ensure_section_exists(section_name):
     # This uses the singleton described above to make sure the section exists
     if not airflow_configuration.conf.has_section(section_name):
         airflow_configuration.conf.add_section(section_name)
+
 
 _ensure_section_exists('fileflow')
 
@@ -74,4 +76,3 @@ def get(section, key, **kwargs):
     # to the actual ConfigParser subclass (conf)
     # to get to it's get() method
     return airflow_configuration.conf.get(section, key, **kwargs)
-

--- a/fileflow/example_dags/fileflow_example.py
+++ b/fileflow/example_dags/fileflow_example.py
@@ -29,7 +29,6 @@ class TaskRunnerReadExample(TaskRunner):
         super(TaskRunnerReadExample, self).__init__(context)
         self.output_template = "Read '{}' from '{}'. Writing output to '{}'."
 
-
     def run(self, *args, **kwargs):
         # This is how you read the output of a previous task
         # The argument to read_upstream_file is based on the DAG configuration
@@ -55,7 +54,9 @@ dag = DAG(
     schedule_interval=timedelta(minutes=1)
 )
 
-# The tasks in this DAG will use DivePythonOperator as the operator, which knows how to send a TaskRunner anything in the `data_dependencies` keyword so you can specify more than one file by name to be fed to a downstream task
+# The tasks in this DAG will use DivePythonOperator as the operator,
+# which knows how to send a TaskRunner anything in the `data_dependencies` keyword
+# so you can specify more than one file by name to be fed to a downstream task
 t1 = DivePythonOperator(
     task_id="write_a_file",
     python_method="run",
@@ -76,4 +77,3 @@ t2 = DivePythonOperator(
     owner="airflow",
     dag=dag
 )
-

--- a/fileflow/example_dags/fileflow_example.py
+++ b/fileflow/example_dags/fileflow_example.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import datetime, timedelta
+
+from airflow import DAG
+
+from fileflow.operators import DivePythonOperator
+from fileflow.task_runners import TaskRunner
+
+
+# Define the logic for your tasks as classes that subclasses from TaskRunner
+# By doing so it will have access to TaskRunner's convenience methods to read and write files
+
+# Here's an easy one that just writes a file.
+class TaskRunnerExample(TaskRunner):
+    def run(self, *args, **kwargs):
+        output_string = "This task -- called {} -- was run.".format(self.task_instance.task_id)
+        self.write_file(output_string)
+        logging.info("Wrote '{}' to '{}'".format(output_string, self.get_output_filename()))
+
+
+# Here's a more complicated one that will read the file from its upstream task, do something, and then write its own file
+# It also shows you how to override __init__ if you need to
+class TaskRunnerReadExample(TaskRunner):
+    def __init__(self, context):
+        """
+        An example how to write the init on a class derived from TaskRunner
+        :param context: Required.
+        """
+        super(TaskRunnerReadExample, self).__init__(context)
+        self.output_template = "Read '{}' from '{}'. Writing output to '{}'."
+
+
+    def run(self, *args, **kwargs):
+        # This is how you read the output of a previous task
+        # The argument to read_upstream_file is based on the DAG configuration
+        input_string = self.read_upstream_file("something")
+
+        # An example bit of 'logic'
+        output_string = self.output_template.format(
+            input_string,
+            self.get_input_filename("something"),
+            self.get_output_filename()
+        )
+
+        # And write out the results of the logic to the correct file
+        self.write_file(output_string)
+
+        logging.info(output_string)
+
+
+# Now let's define a DAG
+dag = DAG(
+    dag_id='fileflow_example',
+    start_date=datetime(2030, 1, 1),
+    schedule_interval=timedelta(minutes=1)
+)
+
+# The tasks in this DAG will use DivePythonOperator as the operator, which knows how to send a TaskRunner anything in the `data_dependencies` keyword so you can specify more than one file by name to be fed to a downstream task
+t1 = DivePythonOperator(
+    task_id="write_a_file",
+    python_method="run",
+    python_object=TaskRunnerExample,
+    provide_context=True,
+    owner="airflow",
+    dag=dag
+)
+
+# We COULD set `python_method="run"` here as above, but "run" is the
+# default value, so we're not bothering to set it
+t2 = DivePythonOperator(
+    task_id="read_that_file",
+    python_object=TaskRunnerReadExample,
+    data_dependencies={"something": t1.task_id},
+    # remember how our TaskRunner subclass knows how to read the upstream file with the key 'something'? This is why
+    provide_context=True,
+    owner="airflow",
+    dag=dag
+)
+

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
                    'mccabe==0.3.1',
                    'flake8==2.5.1',
                    'flake8-debugger==1.4.0',
-                   'pep8-naming==0.3.3']
+                   'pep8-naming==0.3.3'],
+         'docs': ['sphinx==1.5.1',
+                  'sphinx-rtd-theme==0.1.9']
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
                    'flake8==2.5.1',
                    'flake8-debugger==1.4.0',
                    'pep8-naming==0.3.3'],
-         'docs': ['sphinx==1.5.1',
-                  'sphinx-rtd-theme==0.1.9']
+        'docs': ['sphinx==1.5.1',
+                 'sphinx-rtd-theme==0.1.9']
     }
 )

--- a/tests/task_runners/test_taskRunner.py
+++ b/tests/task_runners/test_taskRunner.py
@@ -17,6 +17,7 @@ class TestTaskRunner(TestCase):
     (or a method that calls it) is called with the correct arguments. Mock is used a lot
     here.
     """
+
     def setUp(self):
         # Set up arguments for a :py:class:`airflow.models.TaskInstance`
         # that will be sent to the :py:class:`fileflow.operators.dive_python_operator.DivePythonOperator` class
@@ -125,7 +126,8 @@ class TestTaskRunner(TestCase):
 
     def test_get_output_filename(self):
         """
-        Assert we can parse the current :py:class:`fileflow.task_runners.task_runner.TaskRunner` to pass relevant data needed to infer the this task's
+        Assert we can parse the current :py:class:`fileflow.task_runners.task_runner.TaskRunner`
+        to pass relevant data needed to infer the this task's
         output file location correctly to the storage driver.
         """
         self.task_runner_instance.get_output_filename()


### PR DESCRIPTION
Closes #8. Adds an example DAG with comments and how to run it that showcases the fileflow file backed storage.

To build the docs locally:
given you installed fileflow with `python setup.py install`
you can add the docs libraries you need with `pip install fileflow[docs]`
and run `make docs` from inside the `docs/` folder (where the `Makefile` exists)

I also included in this PR
1) setting it up so that there is an extra_requires for the docs builds (so that testing the rendering is possible above lol)
2) flake8-ing

Must trigger a new docs build on readthedocs after this is merged ❗️ 