### PR TITLE
WIP #13 add circle ci testing for 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ workflows:
   test:
     jobs:
       - linter
-      - test-3.6
-      - test-3.5
+#      - test-3.6
+#      - test-3.5
       - test-2.7
 jobs:
   linter:
@@ -73,11 +73,11 @@ jobs:
             command: |
               . venv/bin/activate
               python setup.py test
-  test-3.5:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5
-  test-2.7:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.6
+#  test-3.5:
+#    <<: *test-template
+#    docker:
+#      - image: circleci/python:3.5
+#  test-2.7:
+#    <<: *test-template
+#    docker:
+#      - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
             flake8 --output-file=misc_artifacts/flake8_report.txt .
   test-3.6: &test-template
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:2.7
     working_directory: ~/repo
 
     steps:
@@ -80,4 +80,4 @@ jobs:
   test-2.7:
     <<: *test-template
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             command: |
               python -m venv venv || virtualenv venv
               . venv/bin/activate
-              pip install -e .
+              pip install -e .[test]
         - save_cache:
             paths:
             - ./venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,83 @@
+version: 2
+workflows:
+  version: 2
+  test:
+    jobs:
+      - linter
+      - test-3.6
+      - test-3.5
+      - test-2.7
+jobs:
+  linter:
+    docker:
+      - image: circleci/python:3.6.1
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: initial lint
+          # crash early on stuff we don't want
+          # merge conflicts, debugger traces, print statements
+          command: |
+            sudo apt-get install -y ack-grep
+            ! ack-grep --ignore-dir=storage --ignore-dir=logs --ignore-dir=tests/test-output -i "<<<<<<<|^=======$|>>>>>>>|>> >> >> >|== == == =|<< << << <" --noyaml .
+
+      # Download the cache of flake8 dependencies if we ran "install flake dependencies" already before for this branch
+      - restore_cache:
+          keys:
+          - flake-dependencies
+      - run:
+          name: install flake dependencies
+          command: |
+            mkdir -p /tmp/venv
+            virtualenv /tmp/venv
+            . /tmp/venv/bin/activate
+            pip install --upgrade pip
+            pip install --no-deps pyflakes==1.0.0 pep8==1.5.7 mccabe==0.3.1 flake8==2.5.1 flake8-debugger==1.4.0 pep8-naming==0.3.3
+      # Save the cache of flake8 dependencies if we haven't run "install flake dependencies" yet before for this branch
+      - save_cache:
+          paths:
+            - "/tmp/venv"
+          key: flake-dependencies
+      - run:
+          name: run flake8
+          command: |
+            . /tmp/venv/bin/activate
+            flake8 --output-file=misc_artifacts/flake8_report.txt .
+  test-3.6: &test-template
+    docker:
+      - image: circleci/python:3.6
+    working_directory: ~/repo
+
+    steps:
+        - checkout
+
+        - restore_cache:
+            keys:
+            - v1-dependencies-{{ checksum "setup.py" }}
+            - v1-dependencies-
+        - run:
+            name: Install test dependencies
+            command: |
+              python -m venv venv || virtualenv venv
+              . venv/bin/activate
+              pip install -e .
+        - save_cache:
+            paths:
+            - ./venv
+            key: v1-dependencies-{{ checksum "setup.py" }}
+        - run:
+            name: Run tests
+            command: |
+              . venv/bin/activate
+              python setup.py test
+  test-3.5:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.5
+  test-2.7:
+    <<: *test-template
+    docker:
+      - image: circleci/python:2.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           command: |
             . /tmp/venv/bin/activate
             flake8 --output-file=misc_artifacts/flake8_report.txt .
-  test-3.6: &test-template
+  test-2.7: &test-template
     docker:
       - image: circleci/python:2.7
     working_directory: ~/repo
@@ -77,7 +77,7 @@ jobs:
 #    <<: *test-template
 #    docker:
 #      - image: circleci/python:3.5
-#  test-2.7:
+#  test-3.6:
 #    <<: *test-template
 #    docker:
 #      - image: circleci/python:3.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # fileflow
 
 [![Documentation Status](https://readthedocs.org/projects/fileflow/badge/?version=latest)](http://fileflow.readthedocs.io/en/latest/?badge=latest)
+[![CircleCI](https://circleci.com/gh/industrydive/fileflow/tree/circle-ci.svg?style=svg)](https://circleci.com/gh/industrydive/fileflow/tree/circle-ci)
 
 Fileflow is a collection of modules that support data transfer between Airflow tasks via file targets and dependencies with either a local file system or S3 backed storage mechanism. The concept is inherited from other pipelining systems such as Make, Drake, Pydoit, and Luigi that organize pipeline dependencies with file targets. In some ways this is an alternative to Airflow's XCOM system, but supports arbitrarily large and arbitrarily formatted data for transfer whereas XCOM can only support a pickle of the size the backend database's BLOB or BINARY LARGE OBJECT implementation can allow.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, find_packages
 from fileflow import __version__
 
+TEST_REQUIRES_PACKAGES = ['moto~=0.4.18', 'coverage~=4.2', 'nose~=1.3.7', 'mock~=1.0.1']
+
 setup(
     name="fileflow",
     version = __version__,
@@ -17,8 +19,9 @@ setup(
         'boto~=2.38.0'
     ],
     test_suite='nose.collector',
-    tests_require=['moto~=0.4.18', 'coverage~=4.2', 'nose~=1.3.7', 'mock~=1.0.1'],
+    tests_require=TEST_REQUIRES_PACKAGES,
     extras_require={
+        'test': TEST_REQUIRES_PACKAGES,
         'flake8': ['pyflakes==1.0.0',
                    'pep8==1.5.7',
                    'mccabe==0.3.1',

--- a/tests/storage_drivers/test_fileStorageDriver.py
+++ b/tests/storage_drivers/test_fileStorageDriver.py
@@ -131,7 +131,7 @@ class TestFileStorageDriver(TestCase):
             '2016-01-03'
         ]
 
-        self.assertListEqual(filenames, expected)
+        self.assertItemsEqual(filenames, expected)
 
     def test_check_or_create_dir(self):
         """


### PR DESCRIPTION
WIP. Relates to #13 and PR #17. Supercedes PR #19.

Includes circle CI test config to run on python 2.7 (and commented out directions for python 3.5 and 3.6 for use in PR #17 shortly). 
